### PR TITLE
Add APK release on tag push

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,34 @@
+name: Android CI
+
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+      - uses: gradle/gradle-build-action@v2
+      - name: Lint Android
+        run: ./gradlew lint
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'zulu'
+      - uses: gradle/gradle-build-action@v2
+      - name: Build
+        run: ./gradlew app:assemble

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,7 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ dev ]
+  workflow_dispatch:
 
 jobs:
   check:
@@ -32,3 +33,22 @@ jobs:
       - uses: gradle/gradle-build-action@v2
       - name: Build
         run: ./gradlew app:assemble
+        
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout code
+      uses: actions/checkout@v3
+    - name: setup jdk
+      uses: actions/setup-java@v1
+      with:
+        java-version: 17
+    - name: Make Gradle executable
+      run: chmod +x ./gradlew
+    - name: Build Release APK
+      run: ./gradlew assembleRelease
+    - name: Releasing using Hub
+      uses: kyze8439690/action-release-releaseapk@master
+      env:
+       GITHUB_TOKEN: ${{ secrets.TOKEN }}
+       APP_FOLDER: app

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,24 +1,56 @@
-name: Android CI
+name: Minimal Android CI Workflow
 
 on:
+  push:
+    branches:
+      - dev
+    tags:
+      - 'v*'
   workflow_dispatch:
 
-jobs:  
-  release:
+jobs:
+  apk:
+    name: Generate APK
     runs-on: ubuntu-latest
     steps:
-    - name: checkout code
-      uses: actions/checkout@v3
-    - name: setup jdk
-      uses: actions/setup-java@v1
-      with:
-        java-version: 17
-    - name: Make Gradle executable
-      run: chmod +x ./gradlew
-    - name: Build Release APK
-      run: ./gradlew assembleRelease
-    - name: Releasing using Hub
-      uses: kyze8439690/action-release-releaseapk@master
-      env:
-       GITHUB_TOKEN: ${{ secrets.TOKEN }}
-       APP_FOLDER: app
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Build APK
+        run: bash ./gradlew assembleDebug --stacktrace
+      - name: Upload APK
+        uses: actions/upload-artifact@v1
+        with:
+          name: apk
+          path: app/build/outputs/apk/debug/app-debug.apk 
+  release:
+    name: Release APK
+    needs: apk
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download APK from build
+        uses: actions/download-artifact@v1
+        with:
+          name: apk  
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }} 
+      - name: Upload Release APK
+        id: upload_release_asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: apk/app-debug.apk
+          asset_name: MensaApp.apk
+          asset_content_type: application/zip

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,39 +1,9 @@
 name: Android CI
 
 on:
-  push:
-    branches: [ dev ]
-  pull_request:
-    branches: [ dev ]
   workflow_dispatch:
 
-jobs:
-  check:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 17
-      - uses: gradle/gradle-build-action@v2
-      - name: Lint Android
-        run: ./gradlew lint
-
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'zulu'
-      - uses: gradle/gradle-build-action@v2
-      - name: Build
-        run: ./gradlew app:assemble
-        
+jobs:  
   release:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,8 @@ name: Minimal Android CI Workflow
 
 on:
   push:
-    branches:
-      - dev
     tags:
       - 'v*'
-  workflow_dispatch:
 
 jobs:
   apk:
@@ -52,5 +49,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: apk/app-debug.apk
-          asset_name: MensaApp.apk
+          asset_name: metro.apk
           asset_content_type: application/zip


### PR DESCRIPTION
This PR adds a new `release` action. When you push a new tag, for example, v6.0.1, it creates a new release with the APK.

This will ensure that the users of Metro Music Player won't have to build the APK themselves and will save time.